### PR TITLE
Add accept attribute

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
   
       <div v-if="!image">
         <h2>Select an image</h2>
-        <input type="file" @change="onFileChange">
+        <input type="file" @change="onFileChange" accept="image/jpeg">
       </div>
       <div v-else>
         <img :src="image" />


### PR DESCRIPTION
Accept attribute may help restrict the selection to jpeg files only as opposed to displaying an error after wrong file type is selected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
