### PR TITLE
fix vue is not a constructor issue by updating vue import

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Upload file to S3</title>
-    <script src="https://unpkg.com/vue"></script>
+    <script src="https://it.vuejs.org/js/vue.min.js"></script>
     <script src="https://unpkg.com/axios@0.2.1/dist/axios.min.js"></script>
   </head>
   <body>


### PR DESCRIPTION
*Issue #, if available:*

Currently getting a "Vue is not a constructor" when index.html is loaded. 

*Description of changes:*

Update the import script to point to the vue.min.js file directly from vue website.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
