### PR TITLE
Update Lambda runtime to NodeJS 16.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Important: this application uses various AWS services and there are costs associ
 
 * AWS CLI already configured with Administrator permission
 * [AWS SAM CLI installed](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) - minimum version 0.48.
-* [NodeJS 12.x installed](https://nodejs.org/en/download/)
+* [NodeJS 16.x installed](https://nodejs.org/en/download/)
 
 ## Installation Instructions
 

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Resources:
     Properties:
       CodeUri: getSignedURL/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       Timeout: 3
       MemorySize: 128
       Environment:

--- a/templateWithAuth.yaml
+++ b/templateWithAuth.yaml
@@ -44,7 +44,7 @@ Resources:
     Properties:
       CodeUri: getSignedURL/
       Handler: app.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs16.x
       MemorySize: 128
       Timeout: 5
       Environment:


### PR DESCRIPTION
This PR update Lambda runtime to NodeJS 16.x, as NodeJS 12.x [will be EOL soon](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
